### PR TITLE
feat: Add automatic release workflow on PR merge

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,57 @@
+name: Auto Release on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  auto-release:
+    name: Auto Release
+    # Only run if PR was merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+
+      - name: Get version from manifest
+        id: get_version
+        run: |
+          VERSION=$(grep -oP '"version":\s*"\K[^"]+' custom_components/nordpool/manifest.json)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "Detected version: $VERSION"
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          if git rev-parse "v${{ steps.get_version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.get_version.outputs.version }} already exists"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag v${{ steps.get_version.outputs.version }} does not exist"
+          fi
+
+      - name: Create and push tag
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release v${{ steps.get_version.outputs.version }}"
+          git push origin "v${{ steps.get_version.outputs.version }}"
+          echo "Created and pushed tag v${{ steps.get_version.outputs.version }}"
+
+      - name: Skip release
+        if: steps.check_tag.outputs.exists == 'true'
+        run: |
+          echo "Tag already exists. Skipping release creation."
+          echo "To create a new release, bump the version in custom_components/nordpool/manifest.json"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,7 +199,21 @@ List any breaking changes (or write "None")
 1. Maintainers will review your PR
 2. Address any requested changes
 3. Once approved, your PR will be merged
-4. Changes will be included in the next release
+4. **Automatic release**: When merged, if the version in `manifest.json` was bumped, a release will be automatically created
+
+### Release Process
+
+This project uses automated releases:
+
+1. **Bump version** in `custom_components/nordpool/manifest.json`
+2. **Update CHANGELOG.md** following [Keep a Changelog](https://keepachangelog.com/) format
+3. **Create PR** with your changes
+4. **Merge PR**: When merged to master, if the version was bumped:
+   - A git tag is automatically created
+   - A GitHub release is automatically published
+   - The release includes the integration zip file for HACS
+
+**Note**: If you merge a PR without bumping the version, no release will be created. This is intentional for non-release changes like documentation updates.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Already using `custom-components/nordpool`? Here's how to switch:
 
 ### Option 1: HACS (Recommended)
 
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Tsopic&repository=nordpool&category=integration)
+
 #### Add Custom Repository
 1. Open HACS in Home Assistant
 2. Click on `Integrations`


### PR DESCRIPTION
## Summary

Implements automated release process that triggers when PRs are merged to master. This eliminates the manual step of creating tags and releases.

## Changes

- **New workflow** (`.github/workflows/auto-release.yml`):
  - Triggers on PR merge to master
  - Reads version from `manifest.json`
  - Creates git tag if version was bumped
  - Skips if tag already exists (prevents duplicate releases)
  - Delegates to existing `release.yml` workflow via tag push

- **Updated documentation** (`CONTRIBUTING.md`):
  - Added release process section
  - Explains automatic release behavior
  - Documents version bump requirements

## How It Works

1. Developer bumps version in `custom_components/nordpool/manifest.json`
2. Updates `CHANGELOG.md` with changes
3. Creates and merges PR
4. **Auto-release workflow**:
   - Detects new version
   - Creates tag `vX.Y.Z`
   - Pushes tag to trigger existing release workflow
5. Release is automatically published with zip file

## Benefits

- **Consistent releases**: No manual tag creation errors
- **Less work**: Maintainers don't need to remember to create releases
- **Flexibility**: Doc-only PRs won't trigger releases (no version bump)
- **Safety**: Won't create duplicate releases if tag exists

## Testing

Tested the workflow logic locally. Ready to test on actual PR merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)